### PR TITLE
Update fragment_visualisation_2d.py to fix bokeh plot

### DIFF
--- a/pages/Fragment_visualisation_pages/fragment_visualisation_2d.py
+++ b/pages/Fragment_visualisation_pages/fragment_visualisation_2d.py
@@ -153,6 +153,7 @@ def plot_fragments(fragments, peptide_sequence):
         title="Fragment Ion Spectrum",
         x_axis_label='m/z',
         y_axis_label='Ion',
+        y_range=fragment_data.data['ion_labels'],
         tools='pan,box_zoom,xbox_zoom,reset,save',
         active_drag='xbox_zoom'
     )


### PR DESCRIPTION
Adds `y_range` parameter so that Bokeh scatter knows how to handle categorical tick labels.